### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build Status](https://travis-ci.org/VerbalExpressions/PHPVerbalExpressions.svg)](https://travis-ci.org/VerbalExpressions/PHPVerbalExpressions)
 
-##PHPVerbalExpressions
+## PHPVerbalExpressions
 - ported from [VerbalExpressions](https://github.com/VerbalExpressions/JSVerbalExpressions)
 
 VerbalExpressions is a PHP library that helps to construct hard regular expressions.  


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
