### PR TITLE
Tests and autoloading updates, use variadic parameters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,4 @@ before_script:
   - composer install
 script:
   - composer check-style
+  - composer test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: php
 php:
-  - '5.3'
-  - '5.4'
-  - '5.5'
   - '5.6'
   - '7.0'
   - hhvm
@@ -10,5 +7,4 @@ php:
 before_script:
   - composer install
 script:
-  - vendor/bin/php-cs-fixer fix --level=psr2 --dry-run src
-  - vendor/bin/php-cs-fixer fix --level=psr2 --dry-run tests/VerbalExpressionsTest.php
+  - composer check-style

--- a/composer.json
+++ b/composer.json
@@ -18,5 +18,10 @@
         "psr-4": {
             "VerbalExpressions\\PHPVerbalExpressions\\": "src/"
         }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "VerbalExpressions\\PHPVerbalExpressions\\Tests\\": "tests/"
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "description": "PHP Regular expressions made easy",
     "require": {
-        "php": ">=5.3",
+        "php": ">=5.6",
         "friendsofphp/php-cs-fixer": "^2.7"
     },
     "require-dev": {
@@ -23,5 +23,10 @@
         "psr-4": {
             "VerbalExpressions\\PHPVerbalExpressions\\Tests\\": "tests/"
         }
+    },
+    "scripts": {
+        "test": "phpunit",
+        "check-style": "phpcs -p --standard=PSR2 --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 src tests",
+        "fix-style": "phpcbf -p --standard=PSR2 --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 src tests"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -4,14 +4,14 @@
     "type": "project",
     "description": "PHP Regular expressions made easy",
     "require": {
-        "php": ">=5.3"
+        "php": ">=5.3",
+        "friendsofphp/php-cs-fixer": "^2.7"
     },
     "require-dev": {
-        "phpunit/phpunit": "* >=4",
-        "fabpot/php-cs-fixer": "^1.11"
+        "phpunit/phpunit": "* >=4"
     },
     "suggest": {
-        "fabpot/php-cs-fixer": "PHP CS Fixer (testing for PSR-2 compliance)"
+        "friendsofphp/php-cs-fixer": "PHP CS Fixer (testing for PSR-2 compliance)"
     },
     "minimum-stability": "stable",
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -5,13 +5,10 @@
     "description": "PHP Regular expressions made easy",
     "require": {
         "php": ">=5.6",
-        "friendsofphp/php-cs-fixer": "^2.7"
+        "squizlabs/php_codesniffer": "^3.1"
     },
     "require-dev": {
         "phpunit/phpunit": "* >=4"
-    },
-    "suggest": {
-        "friendsofphp/php-cs-fixer": "PHP CS Fixer (testing for PSR-2 compliance)"
     },
     "minimum-stability": "stable",
     "autoload": {
@@ -25,7 +22,7 @@
         }
     },
     "scripts": {
-        "test": "phpunit",
+        "test": "vendor/bin/phpunit",
         "check-style": "phpcs -p --standard=PSR2 --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 src tests",
         "fix-style": "phpcbf -p --standard=PSR2 --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 src tests"
     }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,7 +11,7 @@
     stopOnIncomplete="false"
     stopOnSkipped="false"
     syntaxCheck="false"
-    bootstrap="tests/bootstrap.php">
+    bootstrap="vendor/autoload.php">
     <testsuites>
         <testsuite name="Application Test Suite">
             <directory>./tests/</directory>

--- a/src/VerbalExpressions.php
+++ b/src/VerbalExpressions.php
@@ -297,19 +297,18 @@ class VerbalExpressions
      * @return VerbalExpressions
      * @throws \InvalidArgumentException
      */
-    public function range()
+    public function range(... $args)
     {
-        $arg_num = func_num_args();
+        $arg_num = count($args);
 
         if ($arg_num%2 != 0) {
             throw new \InvalidArgumentException('Number of args must be even', 1);
         }
 
         $value = '[';
-        $arg_list = func_get_args();
 
         for ($i = 0; $i < $arg_num;) {
-            $value .= self::sanitize($arg_list[$i++]) . '-' . self::sanitize($arg_list[$i++]);
+            $value .= self::sanitize($args[$i++]) . '-' . self::sanitize($args[$i++]);
         }
 
         $value .= ']';

--- a/tests/VerbalExpressionsTest.php
+++ b/tests/VerbalExpressionsTest.php
@@ -317,7 +317,7 @@ class VerbalExpressionsTest extends TestCase
     /**
     * @depends testGetRegex
     */
-    public function testGetRegex_multiple()
+    public function testGetRegexMultiple()
     {
         $regex = new VerbalExpressions();
         $regex->startOfLine()
@@ -329,7 +329,7 @@ class VerbalExpressionsTest extends TestCase
     /**
     * @expectedException InvalidArgumentException
     */
-    public function testRange_throwsException()
+    public function testRangeThrowsException()
     {
         $regex = new VerbalExpressions();
         $regex->range(1, 2, 3);
@@ -338,7 +338,7 @@ class VerbalExpressionsTest extends TestCase
     /**
     * @depends testGetRegex
     */
-    public function testRange_lowercase()
+    public function testRangeLowercase()
     {
         $lowercaseAlpha = new VerbalExpressions();
         $lowercaseAlpha->range('a', 'z')
@@ -363,7 +363,7 @@ class VerbalExpressionsTest extends TestCase
     /**
     * @depends testGetRegex
     */
-    public function testRange_uppercase()
+    public function testRangeUppercase()
     {
         $uppercaseAlpha = new VerbalExpressions();
         $uppercaseAlpha->range('A', 'Z')
@@ -390,7 +390,7 @@ class VerbalExpressionsTest extends TestCase
     /**
     * @depends testGetRegex
     */
-    public function testRange_numerical()
+    public function testRangeNumerical()
     {
         $zeroToNine = new VerbalExpressions();
         $zeroToNine->range(0, 9)
@@ -421,7 +421,7 @@ class VerbalExpressionsTest extends TestCase
     /**
     * @depends testGetRegex
     */
-    public function testRange_hexadecimal()
+    public function testRangeHexadecimal()
     {
         $hexadecimal = new VerbalExpressions();
         $hexadecimal->startOfLine()
@@ -438,9 +438,9 @@ class VerbalExpressionsTest extends TestCase
     }
 
     /**
-    * @depends testRange_hexadecimal
+    * @depends testRangeHexadecimal
     */
-    public function testRange_md5()
+    public function testRangeMd5()
     {
         $md5 = new VerbalExpressions();
         $md5->startOfLine()
@@ -457,9 +457,9 @@ class VerbalExpressionsTest extends TestCase
     }
 
     /*
-    * @depends testRange_hexadecimal
+    * @depends testRangeHexadecimal
     */
-    public function testRange_sha1()
+    public function testRangeSha1()
     {
         $sha1 = new VerbalExpressions();
         $sha1->startOfLine()

--- a/tests/VerbalExpressionsTest.php
+++ b/tests/VerbalExpressionsTest.php
@@ -1,8 +1,11 @@
 <?php
 
-use VerbalExpressions\PHPVerbalExpressions\VerbalExpressions;
+namespace VerbalExpressions\PHPVerbalExpressions\Tests;
 
-class VerbalExpressionsTest extends PHPUnit_Framework_TestCase
+use VerbalExpressions\PHPVerbalExpressions\VerbalExpressions;
+use PHPUnit\Framework\TestCase;
+
+class VerbalExpressionsTest extends TestCase
 {
     /**
      * @dataProvider provideValidUrls

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,5 +1,0 @@
-<?php
-
-$loader = require dirname(__DIR__) . '/vendor/autoload.php';
-//$loader->add('PHPVerbalExpressions\Tests', __DIR__);
-


### PR DESCRIPTION
At first I wasn't be able to run tests, so I did some changes in that field, accordingly to best practices.
I also switched from user_func_args() to variadic args, which is several times faster as there is no function call overhead. I have described all my actions in commit log.