### PR TITLE
Example+Readme psr2 compliance & moving dependencies

### DIFF
--- a/Example.php
+++ b/Example.php
@@ -10,57 +10,50 @@ $loader = require __DIR__ . '/vendor/autoload.php';
 $regex = new \VerbalExpressions\PHPVerbalExpressions\VerbalExpressions();
 
 $regex->startOfLine()
-	  ->then("http")
-	  ->maybe("s")
-	  ->then("://")
-	  ->maybe("www.")
-	  ->anythingBut(" ")
-	  ->endOfLine();
+      ->then("http")
+      ->maybe("s")
+      ->then("://")
+      ->maybe("www.")
+      ->anythingBut(" ")
+      ->endOfLine();
 
-if($regex->test("http://github.com"))
-	echo "valid url". '<br>';
-else
-	echo "invalid url". '<br>';
+if ($regex->test("http://github.com")) {
+    echo "valid url". '<br>';
+} else {
+    echo "invalid url". '<br>';
+}
 
 if (preg_match($regex, 'http://github.com')) {
-	echo 'valid url';
+    echo 'valid url';
 } else {
-	echo 'invalud url';
+    echo 'invalid url';
 }
 
 echo "<pre>". $regex->getRegex() ."</pre>";
 
 echo $regex->clean(array("modifiers" => "m", "replaceLimit" => 4))
-		   ->find(' ')
-		   ->replace("This is a small test http://somesite.com and some more text.", "-");
+           ->find(' ')
+           ->replace("This is a small test http://somesite.com and some more text.", "-");
 
 
 echo "<hr>";
 
 // limit
 echo $regex ->clean(array("modifiers" => "m"))
-			->startOfLine()
-			->anyOf("abc")
-			->anythingBut(" ")
-			->limit(1)
-			->withAnyCase()
-			->replace("Abracadabra is a nice word", "Ba");
+            ->startOfLine()
+            ->anyOf("abc")
+            ->anythingBut(" ")
+            ->limit(1)
+            ->withAnyCase()
+            ->replace("Abracadabra is a nice word", "Ba");
 
 echo "<br>";
 
 
 
 echo $regex ->clean(array("modifiers" => "gm"))
-			->add("\b")
-			->word()
-			->limit(2, 3)
-			->add("\b")
-			->replace("test abc ab abcd", "*");
-
-
-
-
-
-
-
-
+            ->add("\b")
+            ->word()
+            ->limit(2, 3)
+            ->add("\b")
+            ->replace("test abc ab abcd", "*");

--- a/README.md
+++ b/README.md
@@ -10,21 +10,22 @@ VerbalExpressions is a PHP library that helps to construct hard regular expressi
 
 // some tests
 
-$regex = new VerbalExpressions;
+$regex = new VerbalExpressions();
 
-$regex  ->startOfLine()
-        ->then("http")
-        ->maybe("s")
-        ->then("://")
-        ->maybe("www.")
-        ->anythingBut(" ")
-        ->endOfLine();
+$regex->startOfLine()
+      ->then("http")
+      ->maybe("s")
+      ->then("://")
+      ->maybe("www.")
+      ->anythingBut(" ")
+      ->endOfLine();
 
 
-if($regex->test("https://github.com/"))
-    echo "valid url";
-else
-    echo "invalid url";
+if ($regex->test("http://github.com")) {
+    echo "valid url". '<br>';
+} else {
+    echo "invalid url". '<br>';
+}
 
 if (preg_match($regex, 'http://github.com')) {
     echo 'valid url';
@@ -35,11 +36,9 @@ if (preg_match($regex, 'http://github.com')) {
 
 echo "<pre>". $regex->getRegex() ."</pre>";
 
-
-
-echo $regex ->clean(array("modifiers" => "m", "replaceLimit" => 4))
-            ->find(' ')
-            ->replace("This is a small test http://somesite.com and some more text.", "-");
+echo $regex->clean(array("modifiers" => "m", "replaceLimit" => 4))
+           ->find(' ')
+           ->replace("This is a small test http://somesite.com and some more text.", "-");
 
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -4,11 +4,11 @@
     "type": "project",
     "description": "PHP Regular expressions made easy",
     "require": {
-        "php": ">=5.6",
-        "squizlabs/php_codesniffer": "^3.1"
+        "php": ">=5.6"
     },
     "require-dev": {
-        "phpunit/phpunit": "* >=4"
+        "phpunit/phpunit": "* >=4",
+        "squizlabs/php_codesniffer": "^3.1"
     },
     "minimum-stability": "stable",
     "autoload": {


### PR DESCRIPTION
Moved squizlabs/php_codesniffer to require-dev, since there is zero need for it in a production enviroment.

Adjusted the examples in Example.php and the Readme.md to comply with PSR2, since the whole project has defined it as it's desired standard.